### PR TITLE
Load the diagram JSON from an ArchLens json file

### DIFF
--- a/archlens-in-vscode/src/archlens/archLens.ts
+++ b/archlens-in-vscode/src/archlens/archLens.ts
@@ -1,0 +1,24 @@
+import { spawn } from 'child_process';
+import { readFileAsJSON } from '../filesystem/fileoperations';
+
+export async function getGraphJson(graphPath: string, archLensPath: string): Promise<string> {
+    // Create a promise that resolves when the Python process completes
+    /*await new Promise<void>((resolve, reject) => {
+        const archLensProcess = spawn('python', [archLensPath, 'jsonfile']);
+        
+        archLensProcess.on('error', (error) => {
+            reject(error);
+        });
+
+        archLensProcess.on('close', (code) => {
+            if (code === 0) {
+                resolve();
+            } else {
+                reject(new Error(`Python process exited with code ${code}`));
+            }
+        });
+    });*/
+
+    const graphJson = await readFileAsJSON(graphPath);
+    return graphJson;
+}

--- a/archlens-in-vscode/src/extension.ts
+++ b/archlens-in-vscode/src/extension.ts
@@ -3,6 +3,7 @@
 import * as vscode from 'vscode';
 import { getWebviewContent } from './utilities/getWebviewContent';
 import * as graph_util from "./utilities/graph";
+import * as archlens from './archlens/archLens';
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
@@ -17,7 +18,7 @@ export function activate(context: vscode.ExtensionContext) {
 	// The commandId parameter must match the command field in package.json
 
 	context.subscriptions.push(
-        vscode.commands.registerCommand('archlens-in-vscode.openGraphView', () => {
+        vscode.commands.registerCommand('archlens-in-vscode.openGraphView', async () => {
             const panel = vscode.window.createWebviewPanel(
                 'GraphView',
                 'Graph-view',
@@ -30,6 +31,12 @@ export function activate(context: vscode.ExtensionContext) {
                 }
             );
             
+            const workspaceRootPath = vscode.workspace.workspaceFolders?.[0]?.uri;
+
+            const graphPath = vscode.Uri.joinPath(workspaceRootPath!, "/ArchLens/diagrams/modules.json");
+            const archLensPath = vscode.Uri.joinPath(workspaceRootPath!, "/ArchLens/src/cli_interface.py");
+
+            let g = graph_util.buildGraph(await archlens.getGraphJson(graphPath.toString(), archLensPath.toString()));  
 
             panel.webview.html = getWebviewContent(panel.webview, context.extensionUri);
 
@@ -49,9 +56,7 @@ export function activate(context: vscode.ExtensionContext) {
                 },
                 undefined,
                 context.subscriptions
-            );
-
-            let g = graph_util.buildGraph('{"modules": [{"name": "core", "files": ["bt_file.py", "bt_graph.py", "bt_module.py", "__init__.py"]}, {"name": "plantuml", "files": ["fetch_git.py", "plantuml_file_creator.py", "__init__.py"]}, {"name": "plantumlv2", "files": ["pu_entities.py", "pu_manager.py", "utils.py", "__init__.py"]}, {"name": "utils", "files": ["config_manager_singleton.py", "functions.py", "path_manager_singleton.py", "__init__.py"]}], "files": [{"name": "cli_interface.py", "edge_to": ["path_manager_singleton.py", "config_manager_singleton.py", "pu_manager.py", "bt_graph.py", "fetch_git.py"]}, {"name": "main.py", "edge_to": []}, {"name": "__init__.py", "edge_to": []}, {"name": "bt_file.py", "edge_to": ["bt_module.py"]}, {"name": "bt_graph.py", "edge_to": ["bt_file.py", "bt_module.py"]}, {"name": "bt_module.py", "edge_to": ["bt_file.py"]}, {"name": "__init__.py", "edge_to": []}, {"name": "fetch_git.py", "edge_to": []}, {"name": "plantuml_file_creator.py", "edge_to": ["bt_module.py", "path_manager_singleton.py", "config_manager_singleton.py"]}, {"name": "__init__.py", "edge_to": []}, {"name": "pu_entities.py", "edge_to": ["bt_module.py", "utils.py", "config_manager_singleton.py"]}, {"name": "pu_manager.py", "edge_to": ["bt_graph.py", "pu_entities.py", "utils.py"]}, {"name": "utils.py", "edge_to": ["bt_module.py", "path_manager_singleton.py"]}, {"name": "__init__.py", "edge_to": []}, {"name": "config_manager_singleton.py", "edge_to": []}, {"name": "functions.py", "edge_to": ["bt_graph.py"]}, {"name": "path_manager_singleton.py", "edge_to": []}, {"name": "__init__.py", "edge_to": []}]}')            
+            );  
         })
     );
 

--- a/archlens-in-vscode/src/filesystem/fileoperations.ts
+++ b/archlens-in-vscode/src/filesystem/fileoperations.ts
@@ -1,0 +1,14 @@
+import * as fs from 'fs';
+import { FileSystemError } from 'vscode';
+
+
+function readFileAsJSON(path: string): string {
+
+    if(!fs.existsSync(path)) {
+        throw new FileSystemError(`Could not find file: ${path}`);
+    }
+
+    const fileContent = fs.readFileSync(path, 'utf-8');
+
+    return fileContent;
+}

--- a/archlens-in-vscode/src/filesystem/fileoperations.ts
+++ b/archlens-in-vscode/src/filesystem/fileoperations.ts
@@ -1,14 +1,13 @@
-import * as fs from 'fs';
-import { FileSystemError } from 'vscode';
+import * as vscode from 'vscode';
 
+export async function readFileAsJSON(path: string): Promise<string> {
+    const fileUri = vscode.Uri.parse(path);
 
-function readFileAsJSON(path: string): string {
-
-    if(!fs.existsSync(path)) {
-        throw new FileSystemError(`Could not find file: ${path}`);
+    try {
+        const uri = vscode.Uri.parse(path);
+        const uint8Array = await vscode.workspace.fs.readFile(uri);
+        return new TextDecoder().decode(uint8Array);
+    } catch (error) {
+        throw vscode.FileSystemError.FileNotFound(fileUri);
     }
-
-    const fileContent = fs.readFileSync(path, 'utf-8');
-
-    return fileContent;
 }


### PR DESCRIPTION
The extension now loads the diagram from a JSON file generated by ArchLens.

For now, the extension needs ArchLens to be present as a submodule in the projects root workspace folder. 
This is intended to function with a development version of the extension.

This does not enable the extension to load a diagram from the workspaces' native .diagrams folder. 

close #6